### PR TITLE
Add plugin dependencies

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="DevKit" />
+    <plugin id="com.intellij.uiDesigner" />
+    <plugin id="org.jetbrains.idea.maven" />
+  </component>
+</project>


### PR DESCRIPTION
Fix #7 (if the Maven plugin is not enabled, the libraries can't be downloaded)